### PR TITLE
Allows Jobs to Force no Squad

### DIFF
--- a/code/__DEFINES/squads.dm
+++ b/code/__DEFINES/squads.dm
@@ -1,3 +1,5 @@
+#define SQUAD_NONE "None"
+
 #define SQUAD_ALRICH "Alrich"
 #define SQUAD_BRAVADO "Bravado"
 #define SQUAD_CAESAR "Caesar"

--- a/code/_globalvars/misc.dm
+++ b/code/_globalvars/misc.dm
@@ -34,4 +34,4 @@ GLOBAL_VAR(bible_item_state)
 GLOBAL_VAR(holy_weapon_type)
 GLOBAL_VAR(holy_armor_type)
 
-GLOBAL_LIST_INIT(all_squads, list("None" = null, SQUAD_ALRICH = /datum/antagonist/squad/alrich, SQUAD_BRAVADO = /datum/antagonist/squad/bravado, SQUAD_CAESAR = /datum/antagonist/squad/caesar, SQUAD_DELEON = /datum/antagonist/squad/deleon))
+GLOBAL_LIST_INIT(all_squads, list(SQUAD_NONE = /datum/antagonist/squad/none, SQUAD_ALRICH = /datum/antagonist/squad/alrich, SQUAD_BRAVADO = /datum/antagonist/squad/bravado, SQUAD_CAESAR = /datum/antagonist/squad/caesar, SQUAD_DELEON = /datum/antagonist/squad/deleon))

--- a/code/controllers/subsystem/job.dm
+++ b/code/controllers/subsystem/job.dm
@@ -691,6 +691,9 @@ SUBSYSTEM_DEF(job)
 
 		var/job_squad = job ? job.associated_squad : null
 		var/preferred_squad_datum_type = job_squad ? job_squad : GLOB.all_squads[H.mind.squad]
+		if(!preferred_squad_datum_type)
+			preferred_squad_datum_type = SQUAD_NONE
+			
 		if(preferred_squad_datum_type)
 
 			H.mind.add_antag_datum(preferred_squad_datum_type)

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -145,7 +145,7 @@ GLOBAL_LIST_EMPTY(chosen_names)
 
 	var/crt = FALSE
 
-	var/pref_squad = null
+	var/pref_squad = SQUAD_NONE
 
 	var/list/customizer_entries = list()
 	var/list/list/body_markings = list()
@@ -1664,7 +1664,7 @@ Slots: [job.spawn_positions]</span>
 						prefered_security_department = department
 
 				if("squad_preference")
-					var/squad_preference = input(user, "Choose your preferred squad:", "Squad Preference") as null|anything in GLOB.all_squads
+					var/squad_preference = input(user, "Choose your preferred house:", "House Preference") as null|anything in GLOB.all_squads
 					if(squad_preference)
 						pref_squad = squad_preference
 

--- a/code/modules/jobs/job_types/_job.dm
+++ b/code/modules/jobs/job_types/_job.dm
@@ -140,7 +140,8 @@
 */
 	var/PQ_boost_divider = 0
 
-	var/associated_squad = null // if this is set, this will override the squad the player is assigned to, and they'll be assigned to this squad
+	var/associated_squad = null // if this is set, this will override the squad the player is assigned to regardless of preference.
+	// Set to SQUAD_NONE to force this job to have no squad.
 
 
 /datum/job/proc/special_job_check(mob/dead/new_player/player)

--- a/code/modules/squads/squads.dm
+++ b/code/modules/squads/squads.dm
@@ -28,6 +28,11 @@
 			return H
 
 
+/datum/antagonist/squad/none
+	name = "Unaffliated"
+	antag_hud_type = SQUAD_HUD
+	antag_hud_name = null
+	squad_type = SQUAD_NONE
 
 /datum/antagonist/squad/alrich
 	name = "Alrich Squad Member"
@@ -98,6 +103,9 @@
 /datum/antagonist/squad/remove_innate_effects(mob/living/mob_override)
 	var/mob/living/M = mob_override || owner.current
 	remove_antag_hud(antag_hud_type, M)
+
+/datum/antagonist/squad/none/greet()
+	to_chat(owner, "<span class='notice'>You are not affiliated with any house. You are a lone wolf.</span>")
 
 /datum/antagonist/squad/alrich/greet()
 	to_chat(owner, "<span class='notice'>House Alrich. The pride of Aurorus. Madame Aurorus Alrich.</span>")


### PR DESCRIPTION

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

- Adds a "no squad" type. This person is unaffiliated.
- Allows you to set a job preference to have no squad. Set a job to SQUAD_NONE to do this. Set it to null to just use player preference.


## Why It's Good For The Game

As requested, should be able to have greater control on what jobs do and do not have squads.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
