### PR TITLE
Poison Oak/Ivy

### DIFF
--- a/code/datums/mood_events/generic_negative_events.dm
+++ b/code/datums/mood_events/generic_negative_events.dm
@@ -218,3 +218,11 @@
 	mood_change = -10
 	timeout = 5 MINUTES
 
+/datum/mood_event/itching
+	description = span_warning("This rash is driving me crazy!")
+	mood_change = -6
+	timeout = 2 MINUTES 
+/datum/mood_event/unbearable_itching
+	description = "<span class='boldwarning'>I CAN'T STOP SCRATCHING! MAKE IT STOP!</span>\n"
+	mood_change = -12
+	timeout = 3 MINUTES

--- a/code/game/area/roguetownareas.dm
+++ b/code/game/area/roguetownareas.dm
@@ -59,6 +59,48 @@ GLOBAL_LIST_INIT(roguetown_areas_typecache, typecacheof(/area/rogue/indoors/town
 	droning_sound_night = 'sound/music/area/sleeping.ogg'
 	converted_type = /area/rogue/indoors/shelter
 	soundenv = 16
+	// Flora spawning system
+	var/list/wild_flora = list() // List of flora types and their spawn chances, IE: list(/obj/structure/flora/poisonous_plant/poison_ivy = 50, /obj/structure/flora/poisonous_plant/poison_oak = 50)
+	var/list/wild_turf_types = list(/turf/open/floor/rogue/grass) // Turf types that count as "wild" for flora spawning
+	var/max_wild_flora = 0 // Maximum number of flora to spawn in this area (0 = no limit)
+	var/wild_flora_spawn_chance = 0 // Base chance for each valid turf to spawn flora (0 = no spawning)
+
+/area/rogue/outdoors/Initialize()
+	. = ..()
+	if(wild_flora_spawn_chance > 0 && wild_flora.len > 0 && wild_turf_types.len > 0)
+		spawn(10) // Wait a bit for the map to fully load
+			spawn_wild_flora()
+
+/area/rogue/outdoors/proc/spawn_wild_flora()
+	var/flora_count = 0
+	
+	// Get all turfs in this area
+	for(var/turf/T in src)
+		// Check if this turf is one of the valid wild turf types
+		var/is_valid_turf = FALSE
+		for(var/turf_type in wild_turf_types)
+			if(istype(T, turf_type))
+				is_valid_turf = TRUE
+				break
+		
+		if(!is_valid_turf)
+			continue
+		
+		// Check if there's already flora on this turf
+		if(locate(/obj/structure/flora) in T)
+			continue
+		
+		// Check if we've reached the maximum flora count
+		if(max_wild_flora > 0 && flora_count >= max_wild_flora)
+			break
+		
+		// Roll for spawning
+		if(prob(wild_flora_spawn_chance))
+			// Choose a flora type based on chances
+			var/selected_type = pickweight(wild_flora)
+			if(selected_type)
+				new selected_type(T)
+				flora_count++
 
 /area/rogue/indoors/shelter
 	icon_state = "shelter"
@@ -128,13 +170,26 @@ GLOBAL_LIST_INIT(roguetown_areas_typecache, typecacheof(/area/rogue/indoors/town
 	droning_sound_dusk = 'sound/music/area/septimus.ogg'
 	droning_sound_night = 'sound/music/area/sleeping.ogg'
 	converted_type = /area/rogue/indoors/shelter/rtfield
+	// added flora spawning configuration
+	wild_flora = list(
+		/obj/structure/flora/poisonous_plant/poison_ivy = 50,
+		/obj/structure/flora/poisonous_plant/poison_oak = 50
+	)
+	wild_turf_types = list(/turf/open/floor/rogue/grass)
+	max_wild_flora = 10
+	wild_flora_spawn_chance = 2 // 2% chance for each grass tile to have a poison plant
+
 /area/rogue/indoors/shelter/rtfield
 	icon_state = "rtfield"
 	droning_sound = 'sound/music/area/field.ogg'
 	droning_sound_dusk = 'sound/music/area/septimus.ogg'
 	droning_sound_night = 'sound/music/area/sleeping.ogg'
 
-
+/area/rogue/indoors/shelter/woods
+	icon_state = "woods"
+	droning_sound = 'sound/music/area/forest.ogg'
+	droning_sound_dusk = 'sound/music/area/septimus.ogg'
+	droning_sound_night = 'sound/music/area/sleeping.ogg'
 /area/rogue/outdoors/woods
 	name = "wilderness"
 	icon_state = "woods"
@@ -157,12 +212,14 @@ GLOBAL_LIST_INIT(roguetown_areas_typecache, typecacheof(/area/rogue/indoors/town
 				/mob/living/carbon/human/species/deadite/npc/ambush = 40)
 	first_time_text = "THE MURDERWOOD"
 	converted_type = /area/rogue/indoors/shelter/woods
-/area/rogue/indoors/shelter/woods
-	icon_state = "woods"
-	droning_sound = 'sound/music/area/forest.ogg'
-	droning_sound_dusk = 'sound/music/area/septimus.ogg'
-	droning_sound_night = 'sound/music/area/sleeping.ogg'
 
+	wild_flora = list(
+		/obj/structure/flora/poisonous_plant/poison_ivy = 50,
+		/obj/structure/flora/poisonous_plant/poison_oak = 50
+	)
+	wild_turf_types = list(/turf/open/floor/rogue/grass)
+	max_wild_flora = 15
+	wild_flora_spawn_chance = 3 // 3% chance for each grass tile to have a poison plant
 
 /area/rogue/outdoors/river
 	name = "river"

--- a/code/modules/farming/plant_def.dm
+++ b/code/modules/farming/plant_def.dm
@@ -374,3 +374,30 @@
 	produce_time = 2 MINUTES
 	weed_immune = TRUE
 	can_grow_underground = TRUE
+
+
+/datum/plant_def/poison_oak
+	name = "poison oak patch"
+	icon = 'icons/roguetown/misc/crops.dmi'
+	icon_state = "poison_oak" // placeholder
+	produce_type = /obj/item/reagent_containers/food/snacks/grown/poison_oak
+	produce_amount_min = 2
+	produce_amount_max = 4
+	maturation_nutrition = 25
+	produce_nutrition = 15
+	maturation_time = 4 MINUTES
+	produce_time = 2 MINUTES
+	weed_immune = TRUE
+
+/datum/plant_def/poison_ivy
+	name = "poison ivy patch"
+	icon = 'icons/roguetown/misc/crops.dmi'
+	icon_state = "tea" // placeholder
+	produce_type = /obj/item/reagent_containers/food/snacks/grown/poison_ivy
+	produce_amount_min = 2
+	produce_amount_max = 4
+	maturation_nutrition = 25
+	produce_nutrition = 15
+	maturation_time = 4 MINUTES
+	produce_time = 2 MINUTES
+	weed_immune = TRUE

--- a/code/modules/farming/produce.dm
+++ b/code/modules/farming/produce.dm
@@ -504,3 +504,28 @@
 	tastes = list("numb" = 1)
 	list_reagents = list(/datum/reagent/consumable/nutriment = 3, /datum/reagent/toxin/amanitin = 3)
 	grind_results = list(/datum/reagent/toxin/amanitin = 6)
+
+
+/obj/item/reagent_containers/food/snacks/grown/poison_oak
+	seed = /obj/item/seeds/poison_oak
+	name = "poison oak leaves"
+	icon_state = "sweetleafd" // placeholder
+	filling_color = "#2d5a27"
+	bitesize = 3
+	foodtype = TOXIC
+	tastes = list("burning" = 1)
+	list_reagents = list(/datum/reagent/consumable/nutriment = 2, /datum/reagent/toxin/urushiol = 4)
+	grind_results = list(/datum/reagent/toxin/urushiol = 8)
+	rotprocess = 20 MINUTES
+
+/obj/item/reagent_containers/food/snacks/grown/poison_ivy
+	seed = /obj/item/seeds/poison_ivy
+	name = "poison ivy leaves"
+	icon_state = "tea" // placeholder
+	filling_color = "#2d5a27"
+	bitesize = 3
+	foodtype = TOXIC
+	tastes = list("burning" = 1)
+	list_reagents = list(/datum/reagent/consumable/nutriment = 2, /datum/reagent/toxin/urushiol = 4)
+	grind_results = list(/datum/reagent/toxin/urushiol = 8)
+	rotprocess = 20 MINUTES

--- a/code/modules/farming/seeds.dm
+++ b/code/modules/farming/seeds.dm
@@ -182,3 +182,12 @@
 /obj/item/seeds/mycelium/amanita
 	seed_identity = "red mushroom spores"
 	plant_def_type = /datum/plant_def/amanita
+
+
+/obj/item/seeds/poison_oak
+	seed_identity = "poison oak seeds"
+	plant_def_type = /datum/plant_def/poison_oak
+
+/obj/item/seeds/poison_ivy
+	seed_identity = "poison ivy seeds" 
+	plant_def_type = /datum/plant_def/poison_ivy

--- a/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
@@ -1,4 +1,3 @@
-
 //////////////////////////Poison stuff (Toxins & Acids)///////////////////////
 
 /datum/reagent/toxin
@@ -922,3 +921,34 @@
 		to_chat(M, span_notice("[tox_message]"))
 	. = 1
 	..()
+
+/datum/reagent/toxin/urushiol
+	name = "Urushiol"
+	description = "A toxic oil found in poison ivy, poison oak, and poison sumac. Causes severe itching and rashes."
+	color = "#8B4513" // Brown color
+	toxpwr = 0.5
+	taste_description = "bitter oil"
+	metabolization_rate = 0.2 * REAGENTS_METABOLISM
+	overdose_threshold = 25
+/datum/reagent/toxin/urushiol/on_mob_life(mob/living/carbon/M)
+	if(ishuman(M))
+		var/mob/living/carbon/human/H = M
+		SEND_SIGNAL(H, COMSIG_ADD_MOOD_EVENT, "itching", /datum/mood_event/itching)
+		if(prob(30))
+			to_chat(H, span_danger(pick( // Added missing parenthesis after pick
+			"I scratch frantically at my skin!",
+			"The itching is driving me mad!",
+			"I can't stop scratching!",
+			"My skin feels like it's on fire!",
+			"The rash is spreading and itching intensely!")))  // Added missing parenthesis to close pick()
+			H.adjustBruteLoss(0.5*REM, 0)
+			H.do_jitter_animation(50)
+	return ..()
+
+/datum/reagent/toxin/urushiol/overdose_process(mob/living/M)
+	. = ..()
+	if(current_cycle >=33 && prob(15))
+		if(ishuman(M))
+			var/mob/living/carbon/human/H = M
+			SEND_SIGNAL(H, COMSIG_CLEAR_MOOD_EVENT, "itching")
+			SEND_SIGNAL(H, COMSIG_ADD_MOOD_EVENT, "unbearable_itching", /datum/mood_event/unbearable_itching)


### PR DESCRIPTION

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

- Adds poison oak and poison ivy plants, including seeds and grown produce type.
- The poisonous flora will spawn in grassy areas on the map, not too much, but they do scatter here and there, if you need to increase chances this is configurable in roguetownareas.dm
- Over time they may have a chance of spread, you can change this in flora.dm if you want to set the spread chance to 0.
- Urushiol has been added as a reagent of these plants, it causes itching, and severe itching on overdose - this has a negative mood effect debuff.
- Using a sharp tool or knife will allow you cut these plants away, this will produce the produce holdable item version of them that you can grind up for their reagents.

Note: Icons of existing flora/plants are used as placeholders, you may want to change this. Refer to the files I've put a comment "// placeholder" for them.


https://github.com/user-attachments/assets/01dfcb7a-eb46-4855-ac62-8e5299cf6b5b



<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Adds a source for a reagent you can use as itching potion. You also may have to navigate grassy areas more carefully now.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
