### PR TITLE
Pocket fent, head explosions, sleeping.

### DIFF
--- a/code/__DEFINES/obj_flags.dm
+++ b/code/__DEFINES/obj_flags.dm
@@ -46,4 +46,3 @@
 #define BLOCKS_SHOVE_KNOCKDOWN (1<<10) // Prevents shovies against a dense object from knocking the wearer down.
 #define SNUG_FIT               (1<<11) //Prevents knock-off from things like hat-throwing.
 #define ANTI_TINFOIL_MANEUVER   (1<<12) //Hats with negative effects when worn (i.e the tinfoil hat).
-#define CANT_SLEEP_IN			(1<<13) //Makes you unable to sleep with this on

--- a/code/datums/status_effects/rogue/roguebuff.dm
+++ b/code/datums/status_effects/rogue/roguebuff.dm
@@ -506,3 +506,22 @@
 	name = "Noc's blessing"
 	desc = "Gazing Noc helps me think."
 	icon_state = "buff"
+
+/datum/status_effect/buff/fentanyl
+	id = "dream fold"
+	alert_type = /atom/movable/screen/alert/status_effect/buff/druqks
+	effectedstats = list("endurance" = 4, "speed" = -3, "strength" = -3)
+	duration = 5 MINUTES
+
+/datum/status_effect/buff/fentanyl/nextmove_modifier()
+	return 2
+
+/datum/status_effect/buff/fentanyl/on_apply()
+	. = ..()
+	owner.add_stress(/datum/stressevent/ozium)
+	ADD_TRAIT(owner, TRAIT_NOPAIN, TRAIT_GENERIC)
+
+/datum/status_effect/buff/fentanyl/on_remove()
+	owner.remove_stress(/datum/stressevent/ozium)
+	REMOVE_TRAIT(owner, TRAIT_NOPAIN, TRAIT_GENERIC)
+	. = ..()

--- a/code/datums/wounds/types/fractures.dm
+++ b/code/datums/wounds/types/fractures.dm
@@ -61,8 +61,8 @@
 	)
 	sound_effect = "headcrush"
 	whp = 150
-	sleep_healing = 0
-	/// Most head fractures are serious enough to cause paralysis
+	sleep_healing = 1 //allowed sleep healing because we don't get healers often
+
 	var/paralysis = TRUE
 	/// Some head fractures are so serious they cause instant death
 	var/mortal = FALSE

--- a/code/datums/wounds/types/special.dm
+++ b/code/datums/wounds/types/special.dm
@@ -273,3 +273,85 @@
 			"The testicles are destroyed!",
 			"The testicles are eviscerated!",
 		)
+
+/datum/wound/head_explosion
+	name = "exploded head"
+	check_name = span_danger("<B>AAAAH-</B>")
+	severity = WOUND_SEVERITY_FATAL
+	crit_message = list("%VICTIM's %BODYPART explodes!")
+	sound_effect = "headcrush" // Maps to 'sound/combat/fracture/headcrush (3).ogg'
+	mob_overlay = "dis_head" // Visual for neck stump
+	critical = TRUE
+	can_sew = TRUE // Allows sewing a new head
+	can_cauterize = TRUE // Allows cauterizing
+	disabling = TRUE // Disables head
+	qdel_on_droplimb = TRUE // Wound removed if head dismembered again
+	whp = 75 // Hard to heal
+	sewn_whp = 25
+	bleed_rate = 25 // Heavy bleeding
+	sewn_bleed_rate = 0.25
+	clotting_threshold = null // No clotting
+	sewn_clotting_threshold = null
+	woundpain = 100 // Severe pain
+	sewn_woundpain = 20
+	sew_threshold = 100 // Hard to sew
+	sleep_healing = 0 // No passive healing0
+
+/datum/wound/head_explosion/can_apply_to_bodypart(obj/item/bodypart/affected)
+	if(affected.body_zone != BODY_ZONE_HEAD)
+		return FALSE
+	return ..()
+
+/datum/wound/head_explosion/can_stack_with(datum/wound/other)
+	if(istype(other, /datum/wound/dismemberment/head) || istype(other, /datum/wound/head_explosion))
+		return FALSE
+	return ..()
+
+/datum/wound/head_explosion/on_bodypart_gain(obj/item/bodypart/affected)
+	..()
+	if(!owner || !affected)
+		return
+	playsound(owner, 'sound/combat/fracture/headcrush (3).ogg', 100, vary = TRUE)
+	owner.visible_message(
+		span_danger("<B>[owner]'s head explodes, leaving a bleeding stump!</B>"),
+		span_danger("<B>Your mind is blown!</B>")
+	)
+	if(affected)
+		var/obj/item/bodypart/limb = affected
+		limb.dismember(dam_type = BRUTE) // Drops and dismembers head
+		qdel(limb) // Deletes head
+	// Wound persists for bleeding stump
+
+/datum/wound/head_explosion/on_mob_gain(mob/living/affected)
+	// Skip overlay update to avoid null error
+	if(zombie_infection_timer)
+		deltimer(zombie_infection_timer)
+		zombie_infection_timer = null
+		zombie_infect_attempt()
+	if(werewolf_infection_timer)
+		deltimer(werewolf_infection_timer)
+		werewolf_infection_timer = null
+		werewolf_infect_attempt()
+
+/datum/wound/head_explosion/apply_to_bodypart(obj/item/bodypart/affected, silent = FALSE, crit_message = FALSE)
+	if(QDELETED(affected) || QDELETED(affected.owner))
+		return FALSE
+	if(bodypart_owner)
+		remove_from_bodypart()
+	else if(owner)
+		remove_from_mob()
+	LAZYADD(affected.wounds, src)
+	sortTim(affected.wounds, GLOBAL_PROC_REF(cmp_wound_severity_dsc))
+	bodypart_owner = affected
+	owner = bodypart_owner.owner
+	on_bodypart_gain(affected)
+	on_mob_gain(affected.owner)
+	if(crit_message && owner && !QDELETED(owner)) // Check owner validity
+		var/message = get_crit_message(affected.owner, affected)
+		if(message)
+			owner.next_attack_msg += " [message]"
+	if(!silent && owner && !QDELETED(owner)) // Check owner validity
+		var/sounding = get_sound_effect(affected.owner, affected)
+		if(sounding)
+			playsound(owner, sounding, 100, vary = FALSE)
+	return TRUE

--- a/code/game/objects/structures/fluff.dm
+++ b/code/game/objects/structures/fluff.dm
@@ -980,7 +980,7 @@
 							I += /obj/item/storage/backpack/rogue/backpack
 						if(2)
 							I += /obj/item/reagent_containers/powder/moondust
-							I += /obj/item/reagent_containers/powder/moondust
+							I += /obj/item/reagent_containers/powder/moondust/laced
 							I += /obj/item/reagent_containers/powder/moondust
 							I += /obj/item/bomb
 						if(3)

--- a/code/game/objects/structures/stairs.dm
+++ b/code/game/objects/structures/stairs.dm
@@ -151,3 +151,11 @@
 			var/mob/living/pulled_mob = pulling
 			pulled_mob.grippedby(L, TRUE)
 			L.buckle_mob(pulling, TRUE, TRUE, 90, 0, 0)
+
+
+//Ramps for people to walk up
+/obj/structure/stairs/ramp
+	name = "sloped rock"
+	icon = 'icons/obj/stairs.dmi'
+	icon_state = "stonestairs"
+	max_integrity = 600

--- a/code/modules/cargo/packsrogue/fencer.dm
+++ b/code/modules/cargo/packsrogue/fencer.dm
@@ -19,6 +19,17 @@
 	cost = 30
 	contains = list(/obj/item/reagent_containers/powder/moondust)
 
+/datum/supply_pack/rogue/fencer/moondust
+	name = "Cheap Bulk Moon Dust"
+	cost = 40
+	contains = list(
+					/obj/item/reagent_containers/powder/moondust,
+					/obj/item/reagent_containers/powder/moondust,
+					/obj/item/reagent_containers/powder/moondust/laced,
+					/obj/item/reagent_containers/powder/moondust,
+				)
+
+
 /datum/supply_pack/rogue/fencer/spice
 	name = "Spice"
 	cost = 20

--- a/code/modules/clothing/rogueclothes/armor.dm
+++ b/code/modules/clothing/rogueclothes/armor.dm
@@ -115,7 +115,6 @@
 	unequip_delay_self = 40
 	armor_class = ARMOR_CLASS_HEAVY
 	w_class = WEIGHT_CLASS_BULKY
-	clothing_flags = CANT_SLEEP_IN
 
 /obj/item/clothing/suit/roguetown/armor/plate/half
 	slot_flags = ITEM_SLOT_ARMOR
@@ -183,7 +182,6 @@
 	smeltresult = /obj/item/ingot/steel
 	armor_class = ARMOR_CLASS_HEAVY
 	w_class = WEIGHT_CLASS_BULKY
-	clothing_flags = CANT_SLEEP_IN
 
 /obj/item/clothing/suit/roguetown/armor/jadekingdom/shogun
 	slot_flags = ITEM_SLOT_ARMOR
@@ -202,7 +200,6 @@
 	smeltresult = /obj/item/ingot/steel
 	armor_class = ARMOR_CLASS_HEAVY
 	w_class = WEIGHT_CLASS_BULKY
-	clothing_flags = CANT_SLEEP_IN
 
 /obj/item/clothing/suit/roguetown/armor/brigandine
 	slot_flags = ITEM_SLOT_ARMOR
@@ -221,7 +218,6 @@
 	equip_delay_self = 40
 	armor_class = ARMOR_CLASS_HEAVY
 	w_class = WEIGHT_CLASS_BULKY
-	clothing_flags = CANT_SLEEP_IN
 
 /obj/item/clothing/suit/roguetown/armor/brigandine/Initialize()
 	. = ..()
@@ -297,7 +293,6 @@
 	equip_delay_self = 40
 	armor_class = ARMOR_CLASS_MEDIUM
 	w_class = WEIGHT_CLASS_BULKY
-	clothing_flags = CANT_SLEEP_IN
 	resistance_flags = FIRE_PROOF
 
 /obj/item/clothing/suit/roguetown/armor/armordress
@@ -672,7 +667,6 @@
 	unequip_delay_self = 40
 	armor_class = ARMOR_CLASS_LIGHT
 	w_class = WEIGHT_CLASS_BULKY
-	clothing_flags = CANT_SLEEP_IN
 
 /obj/item/clothing/suit/roguetown/armor/plate/elfnut/silver
 	name = "elvish halfplate armor"
@@ -757,7 +751,6 @@
 	unequip_delay_self = 40
 	armor_class = ARMOR_CLASS_HEAVY
 	w_class = WEIGHT_CLASS_BULKY
-	clothing_flags = CANT_SLEEP_IN
 
 /*
 /obj/item/clothing/suit/roguetown/armor/chainmail/bluesteel

--- a/code/modules/clothing/rogueclothes/hats/hats.dm
+++ b/code/modules/clothing/rogueclothes/hats/hats.dm
@@ -528,7 +528,6 @@
 	w_class = WEIGHT_CLASS_NORMAL
 	armor_class = ARMOR_CLASS_LIGHT
 	resistance_flags = FIRE_PROOF
-	clothing_flags = CANT_SLEEP_IN
 	sewrepair = FALSE
 
 /obj/item/clothing/head/roguetown/helmet/skullcap

--- a/code/modules/clothing/rogueclothes/storage.dm
+++ b/code/modules/clothing/rogueclothes/storage.dm
@@ -295,7 +295,7 @@
 			if(1)
 				new /obj/item/reagent_containers/powder/moondust_purest(src)
 			if(2)
-				new /obj/item/reagent_containers/powder/moondust_purest(src)
+				new /obj/item/reagent_containers/powder/moondust/laced(src)
 			if(3)
 				new /obj/item/reagent_containers/powder/ozium(src)
 			if(4)

--- a/code/modules/jobs/job_types/roguetown/peasants/beggar.dm
+++ b/code/modules/jobs/job_types/roguetown/peasants/beggar.dm
@@ -51,7 +51,7 @@
 	// guaranteed full beggar gear + random stats
 	if(is_wise)
 		head = /obj/item/clothing/head/roguetown/wizhat/gen/wise //wise hat
-		beltr = /obj/item/reagent_containers/powder/moondust
+		beltr = /obj/item/reagent_containers/powder/fentanyl 
 		beltl = /obj/item/clothing/mask/cigarette/rollie/cannabis
 		cloak = /obj/item/clothing/cloak/raincloak/brown
 		gloves = /obj/item/clothing/gloves/roguetown/fingerless

--- a/code/modules/mob/living/carbon/human/npc/bum.dm
+++ b/code/modules/mob/living/carbon/human/npc/bum.dm
@@ -50,7 +50,7 @@ GLOBAL_LIST_INIT(bum_aggro, world.file2list("strings/rt/bumaggrolines.txt"))
 		head = null
 
 	if(prob(5))
-		beltr = /obj/item/reagent_containers/powder/moondust
+		beltr = /obj/item/reagent_containers/powder/fentanyl
 	else
 		beltr = null
 

--- a/code/modules/mob/living/carbon/human/npc/goblin.dm
+++ b/code/modules/mob/living/carbon/human/npc/goblin.dm
@@ -44,6 +44,10 @@
 	name = "hell goblin"
 	raceicon = "goblin_hell"
 
+/datum/species/goblin/hell/spec_death(gibbed, mob/living/carbon/human/H)
+	new /obj/item/reagent_containers/powder/fentanyl(get_turf(H))
+	H.visible_message(span_blue("Dream dust falls from [H]!"))
+
 /mob/living/carbon/human/species/goblin/cave
 	name = "cave goblin"
 	race = /datum/species/goblin/cave

--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -900,7 +900,6 @@ GLOBAL_LIST_INIT(ballmer_windows_me_msg, list("Yo man, what if, we like, uh, put
 *
 *	Accounts for...
 *	TRAIT_NOSLEEP
-*	CANT_SLEEP_IN
 *	TRAIT_NUDE_SLEEPER
 *	Hunger and Hydration.
 */
@@ -910,11 +909,6 @@ GLOBAL_LIST_INIT(ballmer_windows_me_msg, list("Yo man, what if, we like, uh, put
 	var/can_sleep = TRUE
 	var/bleedrate
 	var/cause = list("I can't sleep because...")
-	for(var/obj/item/clothing/thing in get_equipped_items(FALSE))
-		if(thing.clothing_flags & CANT_SLEEP_IN)
-			can_sleep = FALSE
-			cause += " \n\The [thing] bothers me..."
-
 	if(HAS_TRAIT(src, TRAIT_NUDE_SLEEPER))
 		if(length(get_equipped_items()))
 			cause += "I need to be nude to be comfortable..."

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -116,7 +116,7 @@
 		return CLAMP(w_class * 8, 20, 100) // Multiply the item's weight class by 8, then clamp the value between 20 and 100
 	else
 		return 0
-
+/*
 /mob/living/hitby(atom/movable/AM, skipcatch, hitpush = TRUE, blocked = FALSE, datum/thrownthing/throwingdatum, d_type = "blunt")
 	if(istype(AM, /obj/item))
 		var/obj/item/I = AM
@@ -151,7 +151,7 @@
 	else
 		playsound(loc, 'sound/blank.ogg', 50, TRUE, -1) //Item sounds are handled in the item itself
 	..()
-
+*/ //backup
 
 /mob/living/mech_melee_attack(obj/mecha/M)
 	if(M.occupant.used_intent.type == INTENT_HARM)
@@ -612,21 +612,35 @@
 	if(istype(AM, /obj/item))
 		var/obj/item/I = AM
 		var/dtype = BRUTE
-		var/zone = ran_zone(BODY_ZONE_CHEST, 65)//Hits a random part of the body, geared towards the chest
+		var/zone
+		var/mob/living/thrower = throwingdatum?.thrower
+		if(thrower && isliving(thrower) && throwingdatum?.target_zone) // Check if a specific zone was aimed
+			var/accuracy_chance
+			if(thrower.STASKL >= 10)
+				accuracy_chance = 100 // 100% chance at STASKL=10
+			else if(thrower.STASKL >= 7)
+				accuracy_chance = 80 // 80% chance at STASKL=7 to 9
+			else
+				accuracy_chance = 60 // 60% chance at STASKL < 7
+			if(rand(1, 100) <= accuracy_chance) // Skill-based accuracy check
+				zone = throwingdatum.target_zone // Use aimed zone (e.g., BODY_ZONE_HEAD)
+			else
+				zone = ran_zone(BODY_ZONE_CHEST, 65) // Fall back to random zone on miss
+		else
+			zone = ran_zone(BODY_ZONE_CHEST, 65) // Default to random zone with chest bias
 		SEND_SIGNAL(I, COMSIG_MOVABLE_IMPACT_ZONE, src, zone)
 		dtype = I.damtype
 		if(!blocked)
-			var/mob/living/thrower = throwingdatum?.thrower
 			var/is_crit = FALSE
 			var/crit_multiplier = 1.0
 			var/force_crit = FALSE
 
 			// Critical hit check
 			if(thrower && isliving(thrower) && I.can_crit_throw)
-				var/crit_chance = (thrower.STALUC * 1) + (thrower.STASKL * 0.5) + I.crit_bonus // 10% at STALUC=10, +5% at STASKL=10, +item bonus
+				var/crit_chance = (thrower.STALUC * 1) + (thrower.STASKL * 0.5) + I.crit_bonus
 				if(rand(1, 100) <= crit_chance)
 					is_crit = TRUE
-					crit_multiplier = 2.0 // Double damage on crit
+					crit_multiplier = 2.0
 					force_crit = TRUE
 					if(thrower.client?.prefs.showrolls)
 						to_chat(thrower, span_boldwarning("Critical throw!"))
@@ -634,7 +648,7 @@
 									span_danger("I'm critically struck by [I]!"), \
 									null, COMBAT_MESSAGE_RANGE)
 
-			var/armor = run_armor_check(zone, d_type, "", "",I.armor_penetration, damage = I.throwforce * crit_multiplier)
+			var/armor = run_armor_check(zone, d_type, "", "", I.armor_penetration, damage = I.throwforce * crit_multiplier)
 			next_attack_msg.Cut()
 			var/nodmg = FALSE
 			if(!apply_damage(I.throwforce * crit_multiplier, dtype, zone, armor))
@@ -658,5 +672,6 @@
 		else
 			return 1
 	else
-		playsound(loc, 'sound/blank.ogg', 50, TRUE, -1) //Item sounds are handled in the item itself
+		playsound(loc, 'sound/blank.ogg', 50, TRUE, -1) // Item sounds are handled in the item itself
 	..()
+//End CKEEP Stone toss competition code

--- a/code/modules/mob/living/roguetownprocs.dm
+++ b/code/modules/mob/living/roguetownprocs.dm
@@ -144,7 +144,7 @@
 			zone = BODY_ZONE_CHEST
 		if(facing_zone == BODY_ZONE_FACING_R_LEG)
 			chance2hit = (chance2hit / 2)
-	
+
 	if(zone == BODY_ZONE_HEAD)										//Head is the smallest of the Major Body Zones
 		chance2hit *= 0.8
 
@@ -269,21 +269,12 @@
 	var/facing = relative_angular_facing(projlast, target)			//Which side of the target you are attacking
 	var/dist = abs(P.range - P.decayedRange)
 
-	if(P.ricochets >= 1)											//In the event of a ricochet hit
-		var/luck = (rand(1, 20) + (user.STALUC))					//Opposed 1d20+Luck rolls
-		var/luckcheck = (rand(1, 20) + (target.STALUC))
-		if(luck < luckcheck)
-			hit = "Hit"
-			zone = zone_simpmob_target(zone)						//Random body part hit by ricochet strikes
-			return list(zone, hit)
-		else
-			hit = "Miss"
-			zone = check_zone(zone)
-			return list(zone, hit)
+	if(P.ricochets >= 1)
+		zone = zone_simpmob_target(zone) // Random body part for ricochet
+		return list(zone, hit) // Always hit for ricochet
 
-	if(user.mind)													//12 points per skill level, 72 bonus at Legendary
+	if(user.mind)
 		chance2hit += (user.mind.get_skill_level(associated_skill) * 12)
-
 	if(user.mob_size != target.mob_size)							//Size modifier. Easier to hit bigger enemies, harder to hit smaller enemies.
 		chance2hit += ((target.mob_size - user.mob_size) * 10)
 
@@ -302,7 +293,7 @@
 
 	if(istype(user.used_intent, /datum/intent/arc))
 		dist *= 1.5
-	
+
 	chance2hit -= (dist * (6 - ((user.mind.get_skill_level(associated_skill)) * 1)))
 
 	var/facing_zone = facing_zone(zone)
@@ -381,14 +372,12 @@
 				if(!subzone)
 					to_chat(user, span_nicegreen("Hit!"))
 				to_chat(user, span_smallgreen("Roll under [chance2acehit] to Ace Hit... [tohit]"))
-		hit = "Hit"
 		return list(zone, hit)
 	else
 		if(tohit <= chance2hit)
 			if(user.client?.prefs.showrolls && GLOB.Debug2)
 				to_chat(user, span_nicegreen("Hit!"))
 				to_chat(user, span_smallgreen("Roll under [chance2hit] to Hit... [tohit]"))
-			hit = "Hit"
 			zone = check_zone(zone)
 			return list(zone, hit)
 		else
@@ -397,17 +386,16 @@
 					to_chat(user, span_smallgreen("I managed to hit them."))
 					if(GLOB.Debug2)
 						to_chat(user, span_smallgreen("Roll under [scatterhit] to Scatter: [tohit]"))
-				hit = "Hit"
-				zone = zone_simpmob_target(zone)
-				return list(zone, hit)
-			else
+			zone = zone_simpmob_target(zone)
+			return list(zone, hit)
+			/*else
 				if(user.client?.prefs.showrolls)
 					to_chat(user, span_warning("Missed!!"))
 					if(GLOB.Debug2)
 						to_chat(user, span_smallgreen("Roll under [chance2hit] to Hit: [tohit]"))
 				hit = "Miss"
 				zone = check_zone(zone)
-				return list(zone, hit)
+				return list(zone, hit)*/ //projectiles missing if they hit seemed... unfun in practice.
 
 /mob/proc/get_generic_parry_drain()
 	return 30

--- a/code/modules/reagents/reagent_containers/powderspice.dm
+++ b/code/modules/reagents/reagent_containers/powderspice.dm
@@ -89,7 +89,7 @@
 		if(canconsume(C, silent = TRUE))
 			if(reagents.total_volume)
 				playsound(C, 'sound/items/sniff.ogg', 100, FALSE)
-				reagents.trans_to(C, 1, transfered_by = thrownthing.thrower, method = "swallow")
+				reagents.trans_to(C, 5, transfered_by = thrownthing.thrower, method = "swallow")
 	qdel(src)
 
 /obj/item/reagent_containers/powder/attack(mob/M, mob/user, def_zone)
@@ -459,3 +459,67 @@
 //		if(M.client.screen && M.client.screen.len)
 ///			var/atom/movable/screen/plane_master/game_world/PM = locate(/atom/movable/screen/plane_master/game_world) in M.client.screen
 //			PM.backdrop(M.client.mob)
+
+/obj/item/reagent_containers/powder/moondust/laced
+	name = "moondust" //fooolish samooorai, I laced your shit
+	desc = ""
+	volume = 15
+	list_reagents = list(/datum/reagent/moondust = 10, /datum/reagent/fentanyl = 5)
+	grind_results = list(/datum/reagent/moondust = 10, /datum/reagent/fentanyl = 5)
+
+
+
+
+/obj/item/reagent_containers/powder/fentanyl
+	name = "dream dust"//
+	desc = "pure Avarikyan powder"
+	icon = 'icons/roguetown/items/produce.dmi'
+	icon_state = "moondust"
+	possible_transfer_amounts = list()
+	volume = 15
+	list_reagents = list(/datum/reagent/fentanyl = 15)
+	grind_results = list(/datum/reagent/fentanyl = 15)
+	sellprice = 30
+
+/datum/reagent/fentanyl
+	name = "dream dust"
+	description = ""
+	color = "#bfc3b5"
+	overdose_threshold = 5
+	metabolization_rate = 0.2
+
+/datum/reagent/fentanyl/overdose_process(mob/living/M)
+	//M.adjustToxLoss(0.25*REM, 0)
+	..()
+	. = 1
+
+/datum/reagent/fentanyl/on_mob_metabolize(mob/living/M)
+	narcolepsy_drug_up(M)
+	M.overlay_fullscreen("purest_kaif", /atom/movable/screen/fullscreen/purest)
+	animate(M.client, pixel_y = 1, time = 1, loop = -1, flags = ANIMATION_RELATIVE)
+	animate(pixel_y = -1, time = 1, flags = ANIMATION_RELATIVE)
+
+/datum/reagent/fentanyl/on_mob_end_metabolize(mob/living/M)
+	animate(M.client)
+	M.clear_fullscreen("purest_kaif")
+
+/datum/reagent/fentanyl/on_mob_life(mob/living/carbon/M)
+	narcolepsy_drug_up(M)
+	if(M.has_flaw(/datum/charflaw/addiction/junkie))
+		M.sate_addiction()
+	M.apply_status_effect(/datum/status_effect/buff/fentanyl)
+	..()
+
+/datum/reagent/fentanyl/overdose_start(mob/living/M)
+	M.playsound_local(M, 'sound/misc/heroin_rush.ogg', 100, FALSE)
+	M.visible_message(span_warning("[M] folds in half while standing!"))
+	M.adjustOxyLoss(2, 0)
+
+/datum/reagent/fentanyl/overdose_process(mob/living/M)
+	M.adjustToxLoss(3, 0) //
+	M.adjustOxyLoss(3, 0) // Severe respiratory depression
+	M.Sleeping(50, 0)
+	if(prob(20))
+		M.emote("gasp")
+	..()
+	. = 1

--- a/code/modules/roguetown/roguemachine/drugmachine.dm
+++ b/code/modules/roguetown/roguemachine/drugmachine.dm
@@ -231,6 +231,8 @@
 	held_items[/obj/item/reagent_containers/powder/spice] = list("PRICE" = rand(35,50),"NAME" = "spice")
 	held_items[/obj/item/reagent_containers/powder/ozium] = list("PRICE" = rand(17,40),"NAME" = "ozium")
 	held_items[/obj/item/reagent_containers/powder/moondust] = list("PRICE" = rand(45,70),"NAME" = "moondust")
+	held_items[/obj/item/reagent_containers/powder/moondust/laced] = list("PRICE" = rand(15,30),"NAME" = "bargain moondust")
+	held_items[/obj/item/reagent_containers/powder/fentanyl] = list("PRICE" = rand(90,200),"NAME" = "dream dust")
 	held_items[/obj/item/clothing/mask/cigarette/rollie/cannabis] = list("PRICE" = rand(17,30),"NAME" = "swampweed zig")
 	held_items[/obj/item/storage/box/matches] = list("PRICE" = rand(15,25),"NAME" = "tinderbox")
 	held_items[/obj/item/reagent_containers/hypospray/medipen/sty/detox] = list("PRICE" = rand(35,70),"NAME" = "DETOX")

--- a/code/modules/surgery/bodyparts/bodypart_wounds.dm
+++ b/code/modules/surgery/bodyparts/bodypart_wounds.dm
@@ -357,6 +357,19 @@
 	if ((bclass == BCLASS_PUNCH) && (user && dam))
 		if(user && HAS_TRAIT(user, TRAIT_CIVILIZEDBARBARIAN))
 			dam += 20
+		// Head explosion crit for punches
+		if(dam >= 30) // High damage threshold
+			var/strength_check = FALSE
+			if(user && user.STASTR && owner.STACON)
+				strength_check = (user.STASTR >= owner.STACON + 5) // Preferred: 5 more strength than their CON
+			else if(user && user.STASTR)
+				strength_check = (user.STASTR >= 15) // Fallback: 15 strength
+			if(strength_check)
+				var/explosion_chance = 5 // Base 5% chance
+				if(HAS_TRAIT(src, TRAIT_BRITTLE))
+					explosion_chance *= 2 // 10% if brittle
+				if(prob(explosion_chance))
+					attempted_wounds += /datum/wound/head_explosion
 	if((bclass in GLOB.dislocation_bclasses) && (total_dam >= max_damage))
 		used = round(damage_dividend * ((user.STASTR * 0.3) + (dam * 0.3)), 1)
 		used *= ((user?.mind?.get_skill_level(/datum/skill/combat/wrestling) * 0.2) + 1)
@@ -457,8 +470,14 @@
 				else if(!zone_precise in knockout_zones)
 					attempted_wounds += /datum/wound/fracture/head/brain
 
+	// Apply wounds, replacing fractures with head explosion at 5% chance
 	for(var/wound_type in shuffle(attempted_wounds))
-		var/datum/wound/applied = add_wound(wound_type, silent, crit_message)
+		var/apply_wound = wound_type
+		// Check if the wound is a fracture and replace with head_explosion at 5% chance
+		if(ispath(wound_type, /datum/wound/fracture))
+			if(prob(5))
+				apply_wound = /datum/wound/head_explosion
+		var/datum/wound/applied = add_wound(apply_wound, silent, crit_message)
 		if(applied)
 			return applied
 	return FALSE


### PR DESCRIPTION
Gives beggars pocket fent and laces random sources of moon dust. Adds… head explosion crit if you punch someone hard enough. Fixes a bug with throwing items. Fixes the ever famous sleeping with armor bug.

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
I added fentanyl, named dream dust.
added a laced version of moon dust which is exactly the same except it has an almost lethal amount of dream dust cut into it.
You will find various sources of moon dust not bought might have this dream dust in it.
5 units won't kill you, more will. And cut moondust has 5 units.
Throwing a pile of Fentanyl to a player's nose, though, will instantly deliver 5 units of dream dust.

I added head explosions. There's a 5% chance any smash crit just blows up your head. 
If you have 15 STR or 5 STR over their CON, you can just punch people until their head explodes.
Thrown objects were hitting twice.... oopsies. Fixed.

You can sleep in armor again. It was just annoying for the wrong reasons.
## Why It's Good For The Game

Fun, flavor, political commentary. 
